### PR TITLE
chore(docker): Updates image naming convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ _WARN  := "[\33[1;33mWARN\33[0m] %b\n"
 _ERROR := "[ \33[1;31mERR\33[0m] %b\n"
 
 
-all: ur5 keyboard
-	@$(MAKE) stop
+all: ur5 keyboard-container
+	@$(MAKE) --no-print-directory keyboard-ui
+	@$(MAKE) --no-print-directory stop
 
 logs:
 	@docker compose logs --tail=100 -f
@@ -17,29 +18,33 @@ ur5: ur5-stop
 	@xhost +local:rviz-user
 
 	@printf $(_INFO) "Spinning up UR5 teleop simulation"
-	@docker compose up -d --remove-orphans
+	@docker compose up -d --remove-orphans ur5-sim
 
 ur5-stop:
 	@printf $(_INFO) "Ensuring UR5 teleop simulation is down"
-	@if docker ps | grep -q ur5-sim; then \
+	@if docker ps | grep -q mnorma-ur5-sim; then \
 		printf $(_WARN) "Shutting down UR5 teleop simulation"; \
 		docker compose down ur5-sim; \
 		printf $(_INFO) "Closing docker access to X server"; \
 		xhost -local:rviz-user; \
 	fi
 
-keyboard:
-	@printf $(_INFO) "Spinning up keyboard-teleop"
-	@docker exec -it keyboard-teleop \
+keyboard-ui:
+	@printf $(_INFO) "Attaching to keyboard-teleop"
+	@docker exec -it mnorma-keyboard-teleop \
 		bash -ic ". /ws/devel/setup.bash && rosrun keyboard_teleop keyboard_teleop_node"
+
+keyboard-container:
+	@printf $(_INFO) "Spinning up keyboard-teleop container"
+	@docker compose up -d --remove-orphans keyboard-teleop; \
 
 keyboard-stop:
 	@printf $(_INFO) "Ensuring keyboard-teleop is down"
-	@if docker ps | grep -q keyboard-teleop; then \
+	@if docker ps | grep -q mnorma-keyboard-teleop; then \
 		printf $(_WARN) "Shutting down keyboard-teleop"; \
 		docker compose down keyboard-teleop; \
 	fi
 
 build:
-	@printf $(_INFO) "Building UR5 teleop simulation image"
+	@printf $(_INFO) "Building UR5 teleop simulation images"
 	@docker compose build

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The core simulation to be manipulated.
 ## To Do
 
 - [X] UR5 behaves strange from TwistStamped... [#9](https://github.com/m-normand/ur5_teleop_sim/pull/9)
-- [ ] Joint level control of robot
+- [X] Joint level control of robot
 - [ ] First IK Solution
 - [ ] Singularity Compensation
 - [ ] Tracking Optimization

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The core simulation to be manipulated.
 ## To Do
 
 - [X] UR5 behaves strange from TwistStamped... [#9](https://github.com/m-normand/ur5_teleop_sim/pull/9)
-- [X] Joint level control of robot
+- [X] Joint level control of robot... [#13](https://github.com/m-normand/ur5_teleop_sim/pull/13)
 - [ ] First IK Solution
 - [ ] Singularity Compensation
 - [ ] Tracking Optimization

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
     build:
       context: ur5-sim
       dockerfile: Dockerfile
-    container_name: ur5-sim
+    image: mnorma/ur5-sim:latest
+    container_name: mnorma-ur5-sim
     depends_on:
       roscore:
         condition: service_healthy
@@ -45,7 +46,8 @@ services:
     build:
       context: keyboard-teleop
       dockerfile: Dockerfile
-    container_name: keyboard-teleop
+    image: mnorma/keyboard-teleop:latest
+    container_name: mnorma-keyboard-teleop
     depends_on:
       roscore:
         condition: service_healthy


### PR DESCRIPTION
Small update to docker conventions, namely:

Docker images will be called `mnorma/<image>`

Docker containers will be called `mnorma-<container>`

This will make it easier to identify images/containers from this project.